### PR TITLE
16-bit timer1 implementation

### DIFF
--- a/timer/timer.ino
+++ b/timer/timer.ino
@@ -11,13 +11,11 @@
 void timer_init();
 void timer_reset();
 void timer_set(uint16_t period);
-volatile uint8_t counter;
 volatile uint16_t cycle_count;
-#define PRESCALER 8 //prescaler for the timer.
-#define CLOCK 16E6 //Hz. 8MHz nominal (Pro Mini 8MHz), 16MHz for Arduino Uno debugging.
-#define CNTR_MAX 65535 //the maximum value the counter can take before overflowing. 16 bit = 2^16-1; 8 bit = 2^8-1.
-static const float CNTR_FREQ = CLOCK/(PRESCALER * CNTR_MAX);//the frequency in Hz of the counter overflows (how many times it goes from 0 to MAX per second).
-
+static const float PRESCALER = 8; //prescaler for the timer.
+static const float CLOCK = 8E6; //Hz. 8MHz nominal (Pro Mini 8MHz), 16MHz for Arduino Uno.
+static const float CNTR_MAX = 65536; //the maximum value the counter can take before overflowing. 16 bit = 2^16-1; 8 bit = 2^8-1.
+static const float CNTR_FREQ = CLOCK/(PRESCALER);//the frequency in Hz of the peripheral clock/ how fast the hardware counter ticks
 //macro for running an atomic operation. Saves the global interrupt flag (whether interrupts are on or off), turns interrupts off, runs the atomic code, then rewrites interrupt flag.
 
 ISR(TIMER1_COMPA_vect){
@@ -26,23 +24,27 @@ ISR(TIMER1_COMPA_vect){
 
 void setup() {
     Serial.begin(9600);
-    timer_set(1);
     timer_init();
+    timer_set(1);
 }
 
 void loop() {
   Serial.println(cycle_count);
 }
 
-void timer_init(){         
-    // Reset timer counter
-    timer_reset();  
-    //toggle compare output mode on
-    TCCR1A |= B11000000;
-    // Use CTC mode (bits 5 and 4 from left set to 0 1) and set prescaler to 8 (bits 3,2,and 1 from left set to 0 1 0)
-    TCCR1B |= B00001010;
+void timer_init(){    
+    unsigned char sreg;
+    sreg=SREG;
+    cli();        
+    TCCR1A = B01000000;
+    // Use CTC mode (bits 5 and 4 from left set to 0 1) and set prescaler to 1024 (bits 3,2,and 1 from left set to 1 0 1)
+    TCCR1B = B00001010;
   // Enable interrupts; Toggle an interrupt on match with value of OCR1A
     TIMSK1 |= B00000010;  
+    sei();// Reset timer counter
+    
+    timer_reset();  
+    //toggle compare output mode on
 }
 
 void timer_reset(){
@@ -50,10 +52,10 @@ void timer_reset(){
     unsigned char sreg;
     sreg=SREG;
     cli();
-    TCNT1 = 0x0000; //16bit register
+    TCNT1 = 0; //16bit register
     SREG = sreg;
 }
 
 void timer_set(uint16_t period){
-    OCR1A =  (uint16_t)(CNTR_MAX*period)/CNTR_FREQ ;
+    OCR1A =  CNTR_FREQ*period/1000; //left as a float so that the math with CNTR_FREQ does not overflow an integer
 }


### PR DESCRIPTION
-formula for calculating what OCR1A should be based on period 
-max period is 1/CNTR_FREQ. 8MHz prescaled 8 gives a max period of 65ms. Should change to accommodate longer periods.
-crashed when registers were completely overwritten (using =) but worked if only the bits of interest are written (using |=).
